### PR TITLE
Fix function calls, function and attribute names to reenable model usage

### DIFF
--- a/examples/berger_example.py
+++ b/examples/berger_example.py
@@ -40,10 +40,10 @@ def f2(x):
 
 f = [f0, f1, f2]
 
-model = maxentropy.Model(f, samplespace)
+model = maxentropy.Model(f, samplespace, vectorized=False)
 
 # Now set the desired feature expectations
-K = [1.0, 0.3, 0.5]
+K = [[1.0, 0.3, 0.5]]
 
 model.verbose = True
 

--- a/maxentropy/basemodel.py
+++ b/maxentropy/basemodel.py
@@ -280,7 +280,7 @@ class BaseModel(six.with_metaclass(ABCMeta)):
                              'Set these first by calling `fit`.')
 
         # Subsumes both small and large cases:
-        L = self.log_norm_constant() - np.dot(self.params, self.K)
+        L = self.log_partition_function() - np.dot(self.params, self.K)
 
         if self.verbose and self.external is None:
             print("  dual is ", L)
@@ -441,13 +441,13 @@ class BaseModel(six.with_metaclass(ABCMeta)):
         """Returns the normalization constant, or partition function, for
         the current model.  Warning -- this may be too large to represent;
         if so, this will result in numerical overflow.  In this case use
-        log_norm_constant() instead.
+        log_partition_function() instead.
 
         For 'BigModel' instances, estimates the normalization term as
         Z = E_aux_dist [{exp (params.f(X))} / aux_dist(X)] using a sample
         from aux_dist.
         """
-        return np.exp(self.log_norm_constant())
+        return np.exp(self.log_partition_function())
 
 
     def setsmooth(self, sigma):

--- a/maxentropy/model.py
+++ b/maxentropy/model.py
@@ -50,7 +50,7 @@ class Model(BaseModel):
     may be less robust than the gradient-based algorithms.
     """
     def __init__(self, features, samplespace, vectorized=True, format='csc_matrix', verbose=False):
-        super(Model, self).__init__()
+        super(Model, self).__init__(prior_log_probs=None)
         self.samplespace = samplespace
         self.max_output_lines = 20
         self.verbose = verbose
@@ -155,8 +155,8 @@ class Model(BaseModel):
         log_p_dot = self.F.T.dot(self.params)
 
         # Are we minimizing KL divergence?
-        if self.priorlogprobs is not None:
-            log_p_dot += self.priorlogprobs
+        if self.prior_log_probs is not None:
+            log_p_dot += self.prior_log_probs
 
         self.logZ = logsumexp(log_p_dot)
         return self.logZ
@@ -193,8 +193,8 @@ class Model(BaseModel):
         log_p_dot = self.F.T.dot(self.params)
 
         # Do we have a prior distribution p_0?
-        if self.priorlogprobs is not None:
-            log_p_dot += self.priorlogprobs
+        if self.prior_log_probs is not None:
+            log_p_dot += self.prior_log_probs
         if not hasattr(self, 'logZ'):
             # Compute the norm constant (quickly!)
             self.logZ = logsumexp(log_p_dot)

--- a/maxentropy/model.py
+++ b/maxentropy/model.py
@@ -1,5 +1,6 @@
 from scipy.misc import logsumexp
 import numpy as np
+import math
 
 from .basemodel import BaseModel
 from .maxentutils import evaluate_feature_matrix

--- a/maxentropy/model.py
+++ b/maxentropy/model.py
@@ -243,7 +243,7 @@ class Model(BaseModel):
 
         # Do we have a prior distribution p_0?
         priorlogpmf = None
-        if self.priorlogprobs is not None:
+        if self.prior_log_probs is not None:
             try:
                 priorlogpmf = self.priorlogpmf
             except AttributeError:


### PR DESCRIPTION
Some function and attribute names were not matching inside the maxentropy model code, possibly due to copy and paste errors.

Commits included in this PR at least enable usage of `maxentropy.model.Model` with precomputed features, e.g.: 

```python
model = maxentropy.model.Model(features=features, samplespace=samplespace, vectorized=False)
model.fit([K])
```

Consider this [working example](https://git.informatik.uni-leipzig.de/js35jisu/li-lab/blob/master/me-pos-tagger.ipynb).